### PR TITLE
Replace custom properties with PropertyGroup

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -2,7 +2,7 @@ import bpy
 
 
 def is_canvas(obj):
-    if not "Boolean Canvas" in obj:
+    if obj.bool_tool.canvas == False:
         return False
     else:
         cutters = list_canvas_cutters([obj])
@@ -49,11 +49,11 @@ def list_selected_cutters(context):
     if selected_objects:
         for obj in selected_objects:
             if obj != active_object and obj.type == "MESH":
-                if 'Boolean Brush' in obj:
+                if obj.bool_tool.cutter:
                     cutters.append(obj)
 
     if active_object:
-        if 'Boolean Brush' in active_object:
+        if active_object.bool_tool.cutter:
             cutters.append(active_object)
 
     return cutters
@@ -90,7 +90,7 @@ def list_cutter_modifiers(canvases, cutters):
 def list_slices(context, brushes):
     slices = []
     for obj in context.view_layer.objects:
-        if "Boolean Slice" in obj:
+        if obj.bool_tool.slice == True:
             if len(obj.modifiers) >= 1:
                 if any(modifier.object in brushes for modifier in obj.modifiers):
                     if any('boolean_' in modifier.name for modifier in obj.modifiers):

--- a/operators/select.py
+++ b/operators/select.py
@@ -1,5 +1,6 @@
 import bpy
 from ..functions import (
+    is_canvas,
     list_canvases,
     list_selected_cutters,
     list_canvas_cutters,
@@ -17,7 +18,7 @@ class OBJECT_OT_select_cutter_canvas(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        return context.active_object is not None and context.active_object.type == 'MESH' and context.mode == 'OBJECT' and "Boolean Brush" in context.active_object
+        return context.active_object is not None and context.active_object.type == 'MESH' and context.mode == 'OBJECT' and context.active_object.bool_tool.cutter
 
     def execute(self, context):
         brushes = list_selected_cutters(context)
@@ -40,10 +41,10 @@ class OBJECT_OT_select_boolean_all(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        return context.active_object is not None and context.active_object.type == 'MESH' and context.mode == 'OBJECT' and 'Boolean Canvas' in context.active_object
+        return context.active_object is not None and context.active_object.type == 'MESH' and context.mode == 'OBJECT' and is_canvas(context.active_object)
 
     def execute(self, context):
-        canvas = [obj for obj in bpy.context.selected_objects if "Boolean Canvas" in obj]
+        canvas = [obj for obj in bpy.context.selected_objects if obj.bool_tool.canvas == True]
         brushes = list_canvas_cutters(canvas)
 
         # select_cutters

--- a/properties.py
+++ b/properties.py
@@ -5,15 +5,27 @@ import bpy
 
 class BooleanCutters(bpy.types.PropertyGroup):
     cutter: bpy.props.PointerProperty(
-        type=bpy.types.Object,
+        type = bpy.types.Object,
     )
 
 
 class OBJECT_PG_bool_tool(bpy.types.PropertyGroup):
     # OBJECT-level Properties
 
+    canvas: bpy.props.BoolProperty(
+        name = "Boolean Canvas",
+        default = False,
+    )
+    cutter: bpy.props.StringProperty(
+        name = "Boolean Cutter",
+    )
+    slice: bpy.props.BoolProperty(
+        name = "Boolean Slice",
+        default = False,
+    )
+
     cutters: bpy.props.CollectionProperty(
-        type=BooleanCutters,
+        type = BooleanCutters,
     )
 
 

--- a/utilities.py
+++ b/utilities.py
@@ -41,7 +41,7 @@ def duplicate_boolean_modifier(scene, depsgraph):
         # find_original_cutter
         original_cutters = []
         for cutter in cutters:
-            if 'Boolean Brush' in cutter:
+            if cutter.bool_tool.cutter:
                 if ".0" in cutter.name:
                     if ".001" in cutter.name:
                         original_name = cutter.name.split('.')[0]
@@ -52,14 +52,14 @@ def duplicate_boolean_modifier(scene, depsgraph):
 
                     for obj in bpy.data.objects:
                         if obj.name == original_name:
-                            if 'Boolean Brush' in obj:
+                            if obj.bool_tool.cutter:
                                 original_cutters.append(obj)
 
         # duplicate_modifiers
         if original_cutters:
             canvases = list_cutter_users(original_cutters)
             for canvas in canvases:
-                if "Boolean Slice" in canvas:
+                if canvas.bool_tool.slice == True:
                     return
                 
                 for cutter in cutters:


### PR DESCRIPTION
Registering properties needed for add-on to function as user-visible custom properties is risky, users might accidentally broke something. It makes more sense to hide them behind PropertyGroup. Besides that, PropertyGroup is already registered on object level to list cutters, so including other properties in there declutters object properties UI.