### PR TITLE
Carver: Polyline gesture

### DIFF
--- a/functions/draw.py
+++ b/functions/draw.py
@@ -73,7 +73,7 @@ def carver_overlay(self, context):
 
         # circle_around_first_point
         if len(self.mouse_path) > 2:
-            draw_shader(color, 0.6, 'OUTLINE', first_point, size=3)
+            draw_shader(color, 0.8, 'OUTLINE', first_point, size=3)
 
 
     if self.snap and self.move == False:
@@ -92,7 +92,7 @@ def draw_polygon(self):
 
     # Circle around First Point
     radius = self.distance_from_first
-    segments = 16
+    segments = 4
 
     vertices = [coords[0]]
     for i in range(segments + 1):

--- a/functions/draw.py
+++ b/functions/draw.py
@@ -65,10 +65,8 @@ def carver_overlay(self, context):
 
     elif self.shape == 'POLYLINE':
         coords = []
-        indices = []
         for idx, vals in enumerate(self.mouse_path):
             coords.append([vals[0] + self.position_x, vals[1] + self.position_y])
-            indices.append([idx])
 
         type = 'LINE_LOOP' if self.closed else 'LINES'
         draw_shader(color, 1.0, type, coords, size=2)

--- a/functions/draw.py
+++ b/functions/draw.py
@@ -69,7 +69,6 @@ def carver_overlay(self, context):
         for idx, vals in enumerate(self.mouse_path):
             coords.append([vals[0] + self.position_x, vals[1] + self.position_y])
             indices.append([idx])
-        self.verts = coords
 
         type = 'LINE_LOOP' if self.closed else 'LINES'
         draw_shader(color, 1.0, type, coords, size=2)

--- a/functions/mesh.py
+++ b/functions/mesh.py
@@ -92,6 +92,7 @@ def extrude(self, mesh):
 
 def combined_bounding_box(objects):
     """Calculate the combined bounding box of multiple objects."""
+    
     min_corner = mathutils.Vector((float('inf'), float('inf'), float('inf')))
     max_corner = mathutils.Vector((-float('inf'), -float('inf'), -float('inf')))
 

--- a/functions/mesh.py
+++ b/functions/mesh.py
@@ -14,12 +14,14 @@ def create_cutter_shape(self, context):
     depth_location = view3d_utils.region_2d_to_vector_3d(region, rv3d, coords)
     self.view_vector = depth_location
 
-    # Create Mesh & Object
     faces = []
+    vertices = []
+    loc = []
+
+    # Create Mesh & Object
     mesh = bpy.data.meshes.new('cutter_cube')
     bm = bmesh.new()
     bm.from_mesh(mesh)
-
     obj = bpy.data.objects.new('cutter_cube', mesh)
     self.cutter = obj
     context.collection.objects.link(obj)
@@ -34,13 +36,28 @@ def create_cutter_shape(self, context):
         plane_point = mathutils.Vector((0.0, 0.0, 0.0))
 
     # find_the_intersection_of_a_line_going_through_each_vertex_and_the_infinite_plane
-    for vert in self.verts:
-        vec = view3d_utils.region_2d_to_vector_3d(region, rv3d, vert)
-        p0 = view3d_utils.region_2d_to_location_3d(region, rv3d, vert, vec)
-        p1 = p0 + plane_direction
-        faces.append(bm.verts.new(mathutils.geometry.intersect_line_plane(p0, p1, plane_point, plane_direction)))
+    if self.shape == 'POLYLINE':
+        for idx, vert in enumerate(list(dict.fromkeys(self.mouse_path))): # use_dict_to_remove_doubles
+            vec = view3d_utils.region_2d_to_vector_3d(region, rv3d, vert)
+            p0 = view3d_utils.region_2d_to_location_3d(region, rv3d, vert, vec)
+            p1 = p0 + plane_direction
+            loc.append(mathutils.geometry.intersect_line_plane(p0, p1, plane_point, plane_direction))
+            vertices.append(bm.verts.new(loc[idx]))
+
+            if idx > 0:
+                bm.edges.new([vertices[idx-1],vertices[idx]])
+
+            faces.append(vertices[idx])
+    else:
+        for vert in self.verts:
+            vec = view3d_utils.region_2d_to_vector_3d(region, rv3d, vert)
+            p0 = view3d_utils.region_2d_to_location_3d(region, rv3d, vert, vec)
+            p1 = p0 + plane_direction
+            faces.append(bm.verts.new(mathutils.geometry.intersect_line_plane(p0, p1, plane_point, plane_direction)))
 
     bm.verts.index_update()
+    if self.shape == 'POLYLINE' and len(vertices) > 1:
+        bm.edges.new([vertices[-1], vertices[0]])
     to_face = bm.faces.new(faces)
     bm.to_mesh(mesh)
 

--- a/functions/select.py
+++ b/functions/select.py
@@ -74,9 +74,16 @@ def selection_fallback(self, context, objects, include_cutters=False):
 
     # convert_2d_rectangle_coordinates_to_world_coordinates
     if self.origin == 'EDGE':
-        rect_min = mathutils.Vector((min(self.mouse_path[0][0], self.mouse_path[1][0]), min(self.mouse_path[0][1], self.mouse_path[1][1])))
-        rect_max = mathutils.Vector((max(self.mouse_path[0][0], self.mouse_path[1][0]), max(self.mouse_path[0][1], self.mouse_path[1][1])))
-    else:
+        if self.shape != 'POLYLINE':
+            rect_min = mathutils.Vector((min(self.mouse_path[0][0], self.mouse_path[1][0]), min(self.mouse_path[0][1], self.mouse_path[1][1])))
+            rect_max = mathutils.Vector((max(self.mouse_path[0][0], self.mouse_path[1][0]), max(self.mouse_path[0][1], self.mouse_path[1][1])))
+        else:
+            x_values = [point[0] for point in self.mouse_path]
+            y_values = [point[1] for point in self.mouse_path]
+            rect_min = mathutils.Vector((min(x_values), min(y_values)))
+            rect_max = mathutils.Vector((max(x_values), max(y_values)))
+
+    elif self.origin == 'CENTER':
         rect_min = mathutils.Vector((min(self.center_origin[0][0], self.center_origin[1][0]), min(self.center_origin[0][1], self.center_origin[1][1])))
         rect_max = mathutils.Vector((max(self.center_origin[0][0], self.center_origin[1][0]), max(self.center_origin[0][1], self.center_origin[1][1])))
 

--- a/tools/carver.py
+++ b/tools/carver.py
@@ -225,6 +225,8 @@ class OBJECT_OT_carve(bpy.types.Operator):
         self.snap = False
         self.move = False
         self.rotate = False
+
+        # Cache
         self.initial_origin = self.origin
         self.initial_aspect = self.aspect
 
@@ -241,7 +243,8 @@ class OBJECT_OT_carve(bpy.types.Operator):
             self.cancel(context)
             return {'CANCELLED'}
 
-        self.selected_objects = context.selected_objects.copy()
+        self.selected_objects = context.selected_objects
+        self.initial_selection = context.selected_objects
         self.mouse_path[0] = (event.mouse_region_x, event.mouse_region_y)
         self.mouse_path[1] = (event.mouse_region_x, event.mouse_region_y)
 
@@ -386,7 +389,7 @@ class OBJECT_OT_carve(bpy.types.Operator):
 
 
         # Confirm
-        elif (event.type == 'LEFTMOUSE' and event.value == 'RELEASE') or (event.type in 'RET' and event.value == 'PRESS'):
+        elif (event.type == 'LEFTMOUSE' and event.value == 'RELEASE') or (event.type == 'RET' and event.value == 'PRESS'):
             # selection_fallback
             if self.shape != 'POLYLINE':
                 if len(self.selected_objects) == 0:
@@ -403,14 +406,15 @@ class OBJECT_OT_carve(bpy.types.Operator):
                     if empty:
                         return {'FINISHED'}
             else:
-                # expand_selection_fallback_on_every_polyline_click
-                self.selected_objects = selection_fallback(self, context, context.view_layer.objects)
-                for obj in self.selected_objects:
-                    obj.select_set(True)
+                if len(self.initial_selection) == 0:
+                    # expand_selection_fallback_on_every_polyline_click
+                    self.selected_objects = selection_fallback(self, context, context.view_layer.objects)
+                    for obj in self.selected_objects:
+                        obj.select_set(True)
 
             # Polyline
             if self.shape == 'POLYLINE':
-                if not (event.type in 'RET' and event.value == 'PRESS'):
+                if not (event.type == 'RET' and event.value == 'PRESS'):
                     self.mouse_path.append((event.mouse_region_x, event.mouse_region_y))
                     self.mouse_path.append((event.mouse_region_x, event.mouse_region_y))
                 else:

--- a/tools/carver.py
+++ b/tools/carver.py
@@ -378,7 +378,7 @@ class OBJECT_OT_carve(bpy.types.Operator):
 
 
         # Confirm
-        elif (event.type in 'LEFTMOUSE' and event.value == 'RELEASE') or (event.type in 'RET' and event.value == 'PRESS'):
+        elif (event.type == 'LEFTMOUSE' and event.value == 'RELEASE') or (event.type in 'RET' and event.value == 'PRESS'):
             # selection_fallback
             if len(self.selected_objects) == 0:
                 self.selected_objects = selection_fallback(self, context, context.view_layer.objects)
@@ -407,6 +407,12 @@ class OBJECT_OT_carve(bpy.types.Operator):
                     # Confirm Cut (Polyline)
                     if self.closed == False:
                         self.mouse_path.pop() # dont_add_current_mouse_position_as_vert
+
+                    if ((len(self.mouse_path) / 2) < 3) or (self.closed == True and self.mouse_path[-1] == self.mouse_path[-2]):
+                        self.report({'INFO'}, "At least two points are required to make polygonal shape")
+                        self.cancel(context)
+                        return {'FINISHED'}
+
                     self.confirm(context)
                     return {'FINISHED'}
 

--- a/tools/carver.py
+++ b/tools/carver.py
@@ -255,8 +255,8 @@ class OBJECT_OT_carve(bpy.types.Operator):
 
     def modal(self, context, event):
         snap_text = "[MOUSEWHEEL]: Change Snapping Increment" if self.snap else ""
-        shape_text = "[BACKSPACE]: Remove Last Point, " if self.shape == 'POLYLINE' else "[SHIFT]: Aspect, [ALT]: Origin, "
-        context.area.header_text_set("[CTRL]: Snap Invert, [SPACEBAR]: Move, " + shape_text + "[R]: Rotate, " + snap_text)
+        shape_text = "[BACKSPACE]: Remove Last Point, " if self.shape == 'POLYLINE' else "[SHIFT]: Aspect, [ALT]: Origin, [R]: Rotate, "
+        context.area.header_text_set("[CTRL]: Snap Invert, [SPACEBAR]: Move, " + shape_text + snap_text)
 
         # find_the_limit_of_the_3d_viewport_region
         region_types = {'WINDOW', 'UI'}
@@ -305,7 +305,7 @@ class OBJECT_OT_carve(bpy.types.Operator):
 
 
         # ROTATE
-        if event.type == 'R':
+        if event.type == 'R' and (self.shape != 'POLYLINE'):
             if event.value == 'PRESS':
                 context.window.cursor_set("NONE")
                 self.rotate = True

--- a/tools/carver.py
+++ b/tools/carver.py
@@ -340,6 +340,13 @@ class OBJECT_OT_carve(bpy.types.Operator):
             self.initial_position = False
 
 
+        # Remove Point (Polyline)
+        if event.type == 'BACK_SPACE' and event.value == 'PRESS':
+            if len(self.mouse_path) > 2:
+                context.window.cursor_warp(self.mouse_path[-2][0], self.mouse_path[-2][1])
+                self.mouse_path = self.mouse_path[:-2]
+
+
         if event.type in {
                 'MIDDLEMOUSE', 'WHEELUPMOUSE', 'WHEELDOWNMOUSE',
                 'NUMPAD_1', 'NUMPAD_2', 'NUMPAD_3', 'NUMPAD_4', 'NUMPAD_5', 'NUMPAD_6', 'NUMPAD_7', 'NUMPAD_8', 'NUMPAD_9'}:

--- a/tools/carver.py
+++ b/tools/carver.py
@@ -256,7 +256,7 @@ class OBJECT_OT_carve(bpy.types.Operator):
 
     def modal(self, context, event):
         snap_text = ", [MOUSEWHEEL]: Change Snapping Increment" if self.snap else ""
-        shape_text = "[BACKSPACE]: Remove Last Point" if self.shape == 'POLYLINE' else "[SHIFT]: Aspect, [ALT]: Origin, [R]: Rotate"
+        shape_text = "[BACKSPACE]: Remove Last Point, [ENTER]: Confirm" if self.shape == 'POLYLINE' else "[SHIFT]: Aspect, [ALT]: Origin, [R]: Rotate"
         context.area.header_text_set("[CTRL]: Snap Invert, [SPACEBAR]: Move, " + shape_text + snap_text)
 
         # find_the_limit_of_the_3d_viewport_region

--- a/tools/carver.py
+++ b/tools/carver.py
@@ -418,10 +418,13 @@ class OBJECT_OT_carve(bpy.types.Operator):
                     if self.closed == False:
                         self.mouse_path.pop() # dont_add_current_mouse_position_as_vert
 
-                    if ((len(self.mouse_path) / 2) < 2) or (self.closed == True and self.mouse_path[-1] == self.mouse_path[-2]):
+                    if (len(self.mouse_path) / 2) < 2 or (len(self.mouse_path) / 2) == 2 and self.mouse_path[-1] == self.mouse_path[-2]:
                         self.report({'INFO'}, "At least two points are required to make polygonal shape")
                         self.cancel(context)
                         return {'FINISHED'}
+
+                    if self.closed and self.mouse_path[-1] == self.mouse_path[-2]:
+                        context.window.cursor_warp(event.mouse_region_x - 1, event.mouse_region_y)
 
                     # NOTE: Polyline needs separate selection fallback, because it needs to calculate selection bounding box...
                     # NOTE: after all points are already drawn, i.e. before execution.

--- a/tools/carver.py
+++ b/tools/carver.py
@@ -459,6 +459,10 @@ class OBJECT_OT_carve(bpy.types.Operator):
     def Cut(self, context):
         prefs = bpy.context.preferences.addons[base_package].preferences
 
+        # ensure_active_object
+        if not context.active_object:
+            context.view_layer.objects.active = self.selected_objects[0]
+
         # Add Modifier
         for obj in self.selected_objects:
             if self.mode == 'DESTRUCTIVE':


### PR DESCRIPTION
This is the port of polyline gesture for Carver tool and operator from "Carver" add-on (called "Line" in there).

UX is different for Polyline tool, but matches built-in Blender polyline tools as much as possible (more will come in the future): Instead of creating a cut on LMB-release on second click like primitive gestures, each LMB-press creates new point and in between every point polygon (ngon) is created.

---

Changes made from "Carver" add-on implementation:
- Option between closed and open shapes. When 'Closed Polygon' is enabled it takes current mouse position upon execution as last vertice (therefore shape is always closed at the mouse position and filled-in red polygon is drawn). When it's disabled upon execution last drawn vertice and first drawn vertice are connected, disregarding mouse position.
- Enter to finalize the shape and make cut instead of Spacebar: to match internal Blender tools (because of which Spacebar is already occupied by move).
- Moving a polygonal shape is possible with Spacebar.
- Disabled 'Aspect' and 'Origin' properties for polyline, as they're not applicable. `shift` and `alt` modifiers don't do anything.
- Because of changes made to snapping in previous commits, now when snapping all polygon points are snapped to grid, not just active one.
- Operator is cancelled with report message when there are not enough vertices to form a polygon.
- Already drawn points can be removed with backspace while in modal (instead of Ctrl-Z).
- Just like built-in polyline gesture tools, moving cursor close to first point grows circle around it, and clicking on it will close the shape.

Overall tool changes:
- Pressing enter can finalize the shape and execute operator in any shape and mode.
- Operator ensures there is active object. Previously it could sometimes work (or fail) without one.

Rotation isn't implemented for polyline tool for now, as it's more involved and needs better design. Will be tackled in future, but not highest priority.

---

Implementation details:
- Once again reused `create_cutter_shape` function instead of creating new one for polyline and duplicating the code. Difference is just couple of lines between polyline and primitive shapes.
- `TRI_FAN` shader wasn't working in "Carver" and filled polygon wasn't drawn. Fixed it.