### PR TITLE
Carver: Array

### DIFF
--- a/functions/draw.py
+++ b/functions/draw.py
@@ -47,59 +47,51 @@ def carver_overlay(self, context):
     secondary_color = (0.28, 0.04, 0.04, 1.0)
 
     if self.shape == 'CIRCLE':
-        tris_verts, rows, columns = draw_circle(self, self.subdivision, 0)
-        coords = tris_verts[1:] # remove_the_vertex_in_the_center
-        self.verts = coords
-        self.duplicates = {**{f"row_{k}": v for k, v in rows.items()}, **{f"column_{k}": v for k, v in columns.items()}}
+        coords, rows, columns = draw_circle(self, self.subdivision, 0)
+        coords = coords[1:] # remove_extra_vertex
 
         draw_shader(color, 0.4, 'SOLID', coords, size=2)
         if not self.rotate:
-            draw_shader(color, 0.6, 'OUTLINE', get_bounding_box_coords(self, self.verts), size=2)
-
-        # ARRAY
-        if self.rows > 1:
-            for i, duplicate in rows.items():
-                draw_shader(secondary_color, 0.4, 'SOLID', duplicate, size=2)
-        if self.columns > 1:
-            for i, duplicate in columns.items():
-                draw_shader(secondary_color, 0.4, 'SOLID', duplicate, size=2)
+            draw_shader(color, 0.6, 'OUTLINE', get_bounding_box_coords(self, coords), size=2)
 
     elif self.shape == 'BOX':
-        tris_verts, rows, columns = draw_circle(self, 4, 45)
-        coords = tris_verts[1:] # remove_the_vertex_in_the_center
-        self.verts = coords
-        self.duplicates = {**{f"row_{k}": v for k, v in rows.items()}, **{f"column_{k}": v for k, v in columns.items()}}
+        coords, rows, columns = draw_circle(self, 4, 45)
 
         draw_shader(color, 0.4, 'SOLID', coords, size=2)
         if not self.rotate:
-            draw_shader(color, 0.6, 'OUTLINE', get_bounding_box_coords(self, self.verts), size=2)
-
-        # ARRAY
-        if self.rows > 1:
-            for i, duplicate in rows.items():
-                draw_shader(secondary_color, 0.4, 'SOLID', duplicate, size=2)
-        if self.columns > 1:
-            for i, duplicate in columns.items():
-                draw_shader(secondary_color, 0.4, 'SOLID', duplicate, size=2)
+            draw_shader(color, 0.6, 'OUTLINE', get_bounding_box_coords(self, coords), size=2)
 
     elif self.shape == 'POLYLINE':
-        coords, first_point = draw_polygon(self)
+        coords, first_point, rows, columns = draw_polygon(self)
 
         draw_shader(color, 1.0, 'LINE_LOOP' if self.closed else 'LINES', coords, size=2)
         draw_shader(color, 1.0, 'POINTS', coords, size=5)
-        if self.closed:
-            draw_shader(color, 0.4, 'SOLID', coords, size=2)
-
-        # circle_around_first_point
         if len(self.mouse_path) > 2:
-            draw_shader(color, 0.8, 'OUTLINE', first_point, size=3)
+            # polygon_fill
+            if self.closed:
+                draw_shader(color, 0.4, 'SOLID', coords, size=2)
+            # circle_around_first_point
+            draw_shader(color, 0.8, 'OUTLINE', first_point, size=3)       
 
 
+    # Snapping Grid
     if self.snap and self.move == False:
         mini_grid(self, context, color)
 
+    # ARRAY
+    if self.rows > 1:
+        for i, duplicate in rows.items():
+            draw_shader(secondary_color, 0.4, 'SOLID', duplicate, size=2)
+    if self.columns > 1:
+        for i, duplicate in columns.items():
+            draw_shader(secondary_color, 0.4, 'SOLID', duplicate, size=2)
+
     gpu.state.blend_set('NONE')
 
+
+    # gather_operator_values
+    self.verts = coords
+    self.duplicates = {**{f"row_{k}": v for k, v in rows.items()}, **{f"column_{k}": v for k, v in columns.items()}}
 
 
 def draw_polygon(self):
@@ -107,7 +99,7 @@ def draw_polygon(self):
 
     coords = []
     for idx, vals in enumerate(self.mouse_path):
-        coords.append([vals[0] + self.position_x, vals[1] + self.position_y])
+        coords.append(mathutils.Vector([vals[0] + self.position_x, vals[1] + self.position_y, 0.0]))
 
     # Circle around First Point
     radius = self.distance_from_first
@@ -118,9 +110,14 @@ def draw_polygon(self):
         angle = i * (2 * math.pi / segments)
         x = coords[0][0] + radius * math.cos(angle)
         y = coords[0][1] + radius * math.sin(angle)
-        vertices.append((x, y))
+        z = coords[0][2]
+        vector = mathutils.Vector((x, y, z))
+        vertices.append(vector)
 
-    return coords, vertices
+    # ARRAY
+    rows, columns = array(self, coords)
+
+    return coords, vertices, rows, columns
 
 
 def draw_circle(self, subdivision, rotation):
@@ -159,7 +156,7 @@ def draw_circle(self, subdivision, rotation):
 
     # ORIGIN: from the Center
     if self.origin == 'CENTER':
-        for idx in range(len(verts) // 3):
+        for idx in range((len(verts) // 3) - 1):
             x = verts[idx * 3]
             y = verts[idx * 3 + 1]
             z = verts[idx * 3 + 2]
@@ -172,7 +169,7 @@ def draw_circle(self, subdivision, rotation):
 
     # ORIGIN: from the Top Left Corner
     elif self.origin == 'EDGE':
-        for idx in range(len(verts) // 3):
+        for idx in range((len(verts) // 3) - 1):
             x = verts[idx * 3]
             y = verts[idx * 3 + 1]
             z = verts[idx * 3 + 2]
@@ -183,23 +180,8 @@ def draw_circle(self, subdivision, rotation):
 
             tris_verts.append(vert)
 
-
     # ARRAY
-    rows = {}
-    if self.rows > 1:
-        offset = mathutils.Vector(((self.gap_rows * 100), 0.0, 0.0))
-        for i in range(self.rows - 1):
-            accumulated_offset = offset * (i + 1)
-            rows[i] = [vert.copy() + accumulated_offset for vert in tris_verts]
-
-    columns = {}
-    if self.columns > 1:
-        offset = mathutils.Vector((0.0, -(self.gap_rows * 100), 0.0))
-        for i in range(self.columns - 1):
-            accumulated_offset = offset * (i + 1)
-            columns[i] = [vert.copy() + accumulated_offset for vert in tris_verts]
-            for row_idx, row in rows.items():
-                columns[(i, row_idx)] = [vert.copy() + accumulated_offset for vert in row]
+    rows, columns = array(self, tris_verts)
 
     return tris_verts, rows, columns
 
@@ -269,3 +251,27 @@ def get_bounding_box_coords(self, coords):
     ]
 
     return bounding_box_coords
+
+
+def array(self, verts):
+    """Duplicates given list of vertices in rows and columns (on x and y axis)"""
+    """Returns two dicts of lists of vertices for rows and columns separately"""
+
+    # ARRAY
+    rows = {}
+    if self.rows > 1:
+        offset = mathutils.Vector(((self.gap_rows * 100), 0.0, 0.0))
+        for i in range(self.rows - 1):
+            accumulated_offset = offset * (i + 1)
+            rows[i] = [vert.copy() + accumulated_offset for vert in verts]
+
+    columns = {}
+    if self.columns > 1:
+        offset = mathutils.Vector((0.0, -(self.gap_rows * 100), 0.0))
+        for i in range(self.columns - 1):
+            accumulated_offset = offset * (i + 1)
+            columns[i] = [vert.copy() + accumulated_offset for vert in verts]
+            for row_idx, row in rows.items():
+                columns[(i, row_idx)] = [vert.copy() + accumulated_offset for vert in row]
+
+    return rows, columns

--- a/functions/draw.py
+++ b/functions/draw.py
@@ -115,6 +115,7 @@ def draw_polygon(self):
         vertices.append(vector)
 
     # ARRAY
+    get_bounding_box_coords(self, coords)
     rows, columns = array(self, coords)
 
     return coords, vertices, rows, columns
@@ -186,7 +187,7 @@ def draw_circle(self, subdivision, rotation):
     return tris_verts, rows, columns
 
 
-def mini_grid(self, context, color):
+def mini_grid(self, context):
     """Draws snap mini-grid around the cursor based on the overlay grid"""
 
     region = context.region
@@ -233,13 +234,13 @@ def mini_grid(self, context, color):
         draw_shader((1.0, 1.0, 1.0), 0.66, 'LINES', grid_coords, size=1.5)
 
 
-def get_bounding_box_coords(self, coords):
+def get_bounding_box_coords(self, verts):
     """Calculates the bounding box coordinates from a list of vertices in a counter-clockwise order"""
 
-    min_x = min(v[0] for v in coords)
-    max_x = max(v[0] for v in coords)
-    min_y = min(v[1] for v in coords)
-    max_y = max(v[1] for v in coords)
+    min_x = min(v[0] for v in verts)
+    max_x = max(v[0] for v in verts)
+    min_y = min(v[1] for v in verts)
+    max_y = max(v[1] for v in verts)
     self.center_origin = [(min_x, min_y), (max_x, max_y)]
 
     bounding_box_coords = [
@@ -257,17 +258,17 @@ def array(self, verts):
     """Duplicates given list of vertices in rows and columns (on x and y axis)"""
     """Returns two dicts of lists of vertices for rows and columns separately"""
 
-    # ARRAY
     rows = {}
     if self.rows > 1:
-        offset = mathutils.Vector(((self.gap_rows * 100), 0.0, 0.0))
+        offset = mathutils.Vector(((self.center_origin[1][0] - self.center_origin[0][0]) + (self.gap_rows), 0.0, 0.0))
         for i in range(self.rows - 1):
             accumulated_offset = offset * (i + 1)
             rows[i] = [vert.copy() + accumulated_offset for vert in verts]
 
     columns = {}
     if self.columns > 1:
-        offset = mathutils.Vector((0.0, -(self.gap_rows * 100), 0.0))
+        offset_2 = (self.center_origin[1][1] - self.center_origin[0][1]) + (self.gap_columns)
+        offset = mathutils.Vector((0.0, -offset_2, 0.0))
         for i in range(self.columns - 1):
             accumulated_offset = offset * (i + 1)
             columns[i] = [vert.copy() + accumulated_offset for vert in verts]

--- a/functions/draw.py
+++ b/functions/draw.py
@@ -76,7 +76,7 @@ def carver_overlay(self, context):
 
     # Snapping Grid
     if self.snap and self.move == False:
-        mini_grid(self, context, color)
+        mini_grid(self, context)
 
     # ARRAY
     if self.rows > 1:
@@ -260,14 +260,22 @@ def array(self, verts):
 
     rows = {}
     if self.rows > 1:
-        offset = mathutils.Vector(((self.center_origin[1][0] - self.center_origin[0][0]) + (self.gap_rows), 0.0, 0.0))
+        # Offset
+        offset = mathutils.Vector((((self.center_origin[1][0] - self.center_origin[0][0]) + (self.rows_gap)), 0.0, 0.0))
+        if self.rows_direction == 'LEFT':
+            offset.x = -offset.x
+
         for i in range(self.rows - 1):
             accumulated_offset = offset * (i + 1)
             rows[i] = [vert.copy() + accumulated_offset for vert in verts]
 
     columns = {}
     if self.columns > 1:
-        offset = mathutils.Vector((0.0, -((self.center_origin[1][1] - self.center_origin[0][1]) + (self.gap_columns)), 0.0))
+        # Offset
+        offset = mathutils.Vector((0.0, -((self.center_origin[1][1] - self.center_origin[0][1]) + (self.columns_gap)), 0.0))
+        if self.columns_direction == 'UP':
+            offset.y = -offset.y
+
         for i in range(self.columns - 1):
             accumulated_offset = offset * (i + 1)
             columns[i] = [vert.copy() + accumulated_offset for vert in verts]

--- a/functions/draw.py
+++ b/functions/draw.py
@@ -50,6 +50,7 @@ def carver_overlay(self, context):
         tris_verts, rows, columns = draw_circle(self, self.subdivision, 0)
         coords = tris_verts[1:] # remove_the_vertex_in_the_center
         self.verts = coords
+        self.duplicates = {**{f"row_{k}": v for k, v in rows.items()}, **{f"column_{k}": v for k, v in columns.items()}}
 
         draw_shader(color, 0.4, 'SOLID', coords, size=2)
         if not self.rotate:
@@ -67,6 +68,7 @@ def carver_overlay(self, context):
         tris_verts, rows, columns = draw_circle(self, 4, 45)
         coords = tris_verts[1:] # remove_the_vertex_in_the_center
         self.verts = coords
+        self.duplicates = {**{f"row_{k}": v for k, v in rows.items()}, **{f"column_{k}": v for k, v in columns.items()}}
 
         draw_shader(color, 0.4, 'SOLID', coords, size=2)
         if not self.rotate:

--- a/functions/draw.py
+++ b/functions/draw.py
@@ -267,8 +267,7 @@ def array(self, verts):
 
     columns = {}
     if self.columns > 1:
-        offset_2 = (self.center_origin[1][1] - self.center_origin[0][1]) + (self.gap_columns)
-        offset = mathutils.Vector((0.0, -offset_2, 0.0))
+        offset = mathutils.Vector((0.0, -((self.center_origin[1][1] - self.center_origin[0][1]) + (self.gap_columns)), 0.0))
         for i in range(self.columns - 1):
             accumulated_offset = offset * (i + 1)
             columns[i] = [vert.copy() + accumulated_offset for vert in verts]

--- a/functions/mesh.py
+++ b/functions/mesh.py
@@ -7,72 +7,44 @@ from bpy_extras import view3d_utils
 def create_cutter_shape(self, context):
     """Creates flat mesh from the vertices provided in `self.verts` (which is created by `carver_overlay`)"""
 
-    far_limit = 10000.0
+    # ALIGNMENT: View
     coords = self.mouse_path[0][0], self.mouse_path[0][1]
     region = context.region
     rv3d = context.region_data
     depth_location = view3d_utils.region_2d_to_vector_3d(region, rv3d, coords)
     self.view_vector = depth_location
-
-    faces = {}
-    vertices = []
-    loc = []
-
-    # Create Mesh & Object
-    mesh = bpy.data.meshes.new('cutter_cube')
-    bm = bmesh.new()
-    bm.from_mesh(mesh)
-    obj = bpy.data.objects.new('cutter_cube', mesh)
-    self.cutter = obj
-    context.collection.objects.link(obj)
-
-    # Orientation: VIEW
     plane_direction = depth_location.normalized()
 
-    # Depth
+    # depth
     if self.depth == 'CURSOR':
         plane_point = context.scene.cursor.location
     elif self.depth == 'VIEW':
         plane_point = mathutils.Vector((0.0, 0.0, 0.0))
 
 
-    # find_the_intersection_of_a_line_going_through_each_vertex_and_the_infinite_plane
-    if self.shape == 'POLYLINE':
-        for idx, vert in enumerate(list(dict.fromkeys(self.mouse_path))): # use_dict_to_remove_doubles
-            vec = view3d_utils.region_2d_to_vector_3d(region, rv3d, vert)
-            p0 = view3d_utils.region_2d_to_location_3d(region, rv3d, vert, vec)
-            p1 = p0 + plane_direction
-            loc.append(mathutils.geometry.intersect_line_plane(p0, p1, plane_point, plane_direction))
-            vertices.append(bm.verts.new(loc[idx]))
+    # Create Mesh & Object
+    faces = {}
+    mesh = bpy.data.meshes.new('cutter_cube')
+    bm = bmesh.new()
+    bm.from_mesh(mesh)
 
-            if idx > 0:
-                bm.edges.new([vertices[idx-1],vertices[idx]])
+    obj = bpy.data.objects.new('cutter_cube', mesh)
+    self.cutter = obj
+    context.collection.objects.link(obj)
 
-            faces.append(vertices[idx])
-    else:
-        faces['original'] = []
-        for vert in self.verts:
-            vec = view3d_utils.region_2d_to_vector_3d(region, rv3d, vert)
-            p0 = view3d_utils.region_2d_to_location_3d(region, rv3d, vert, vec)
-            p1 = p0 + plane_direction
-            faces['original'].append(bm.verts.new(mathutils.geometry.intersect_line_plane(p0, p1, plane_point, plane_direction)))
+    # Create Faces from `self.verts`
+    create_face(context, plane_direction, plane_point,
+                bm, "original", faces, self.verts)
 
-        if len(self.duplicates) > 0:
-            for i, duplicate in self.duplicates.items():
-                faces[str(i)] = []
-                for vert in duplicate:
-                    vec = view3d_utils.region_2d_to_vector_3d(region, rv3d, vert)
-                    p0 = view3d_utils.region_2d_to_location_3d(region, rv3d, vert, vec)
-                    p1 = p0 + plane_direction
-                    faces[str(i)].append(bm.verts.new(mathutils.geometry.intersect_line_plane(p0, p1, plane_point, plane_direction)))
+    # ARRAY
+    if len(self.duplicates) > 0:
+        for i, duplicate in self.duplicates.items():
+            create_face(context, plane_direction, plane_point,
+                        bm, str(i), faces, duplicate)
 
     bm.verts.index_update()
-    if self.shape == 'POLYLINE' and len(vertices) > 1:
-        bm.edges.new([vertices[-1], vertices[0]])
-    
     for i, face in faces.items():
-        to_face = bm.faces.new(face)
-
+        bm.faces.new(face)
     bm.to_mesh(mesh)
 
 
@@ -125,3 +97,28 @@ def combined_bounding_box(objects):
     # Calculate the diagonal of the combined bounding box
     bounding_box_diag = (max_corner - min_corner).length
     return bounding_box_diag
+
+
+def create_face(context, direction, depth, bm, name, faces, verts, polyline=False):
+    """Creates bmesh face with given list of vertices and appends it to given 'faces' dict"""
+
+    def intersect_line_plane(context, vert, direction, depth):
+        """Finds the intersection of a line going through each vertex and the infinite plane"""
+
+        region = context.region
+        rv3d = context.region_data
+
+        vec = view3d_utils.region_2d_to_vector_3d(region, rv3d, vert)
+        p0 = view3d_utils.region_2d_to_location_3d(region, rv3d, vert, vec)
+        p1 = p0 + direction
+        loc = mathutils.geometry.intersect_line_plane(p0, p1, depth, direction)
+
+        return loc
+
+    face_verts = []
+    for i, vert in enumerate(verts):
+        loc = intersect_line_plane(context, vert, direction, depth)
+        vertex = bm.verts.new(loc)
+        face_verts.append(vertex)
+
+    faces[name] = face_verts

--- a/functions/select.py
+++ b/functions/select.py
@@ -93,9 +93,9 @@ def selection_fallback(self, context, objects, include_cutters=False):
 
     # ARRAY
     if self.rows > 1:
-        rect_max.x = rect_min.x + (rect_max.x - rect_min.x) * self.rows + (self.gap_rows * (self.rows - 1))
+        rect_max.x = rect_min.x + (rect_max.x - rect_min.x) * self.rows + (self.rows_gap * (self.rows - 1))
     if self.columns > 1:
-        rect_min.y = rect_max.y - (rect_max.y - rect_min.y) * self.columns - (self.gap_columns * (self.columns - 1))
+        rect_min.y = rect_max.y - (rect_max.y - rect_min.y) * self.columns - (self.columns_gap * (self.columns - 1))
 
     intersecting_objects = []
     for obj in objects:

--- a/functions/select.py
+++ b/functions/select.py
@@ -45,7 +45,7 @@ def cursor_snap(self, context, event, mouse_pos):
 
 
 def is_inside_selection(context, obj, rect_min, rect_max):
-    """Checks if the bounding box of an object intersects with the selection rectangle"""
+    """Checks if the bounding box of an object intersects with the selection bounding box"""
 
     region = context.region
     rv3d = context.space_data.region_3d
@@ -74,18 +74,28 @@ def selection_fallback(self, context, objects, include_cutters=False):
 
     # convert_2d_rectangle_coordinates_to_world_coordinates
     if self.origin == 'EDGE':
-        if self.shape != 'POLYLINE':
-            rect_min = mathutils.Vector((min(self.mouse_path[0][0], self.mouse_path[1][0]), min(self.mouse_path[0][1], self.mouse_path[1][1])))
-            rect_max = mathutils.Vector((max(self.mouse_path[0][0], self.mouse_path[1][0]), max(self.mouse_path[0][1], self.mouse_path[1][1])))
-        else:
+        if self.shape == 'POLYLINE':
             x_values = [point[0] for point in self.mouse_path]
             y_values = [point[1] for point in self.mouse_path]
             rect_min = mathutils.Vector((min(x_values), min(y_values)))
             rect_max = mathutils.Vector((max(x_values), max(y_values)))
+        else:
+            rect_min = mathutils.Vector((min(self.mouse_path[0][0], self.mouse_path[1][0]),
+                                        min(self.mouse_path[0][1], self.mouse_path[1][1])))
+            rect_max = mathutils.Vector((max(self.mouse_path[0][0], self.mouse_path[1][0]),
+                                        max(self.mouse_path[0][1], self.mouse_path[1][1])))
 
     elif self.origin == 'CENTER':
-        rect_min = mathutils.Vector((min(self.center_origin[0][0], self.center_origin[1][0]), min(self.center_origin[0][1], self.center_origin[1][1])))
-        rect_max = mathutils.Vector((max(self.center_origin[0][0], self.center_origin[1][0]), max(self.center_origin[0][1], self.center_origin[1][1])))
+        rect_min = mathutils.Vector((min(self.center_origin[0][0], self.center_origin[1][0]),
+                                     min(self.center_origin[0][1], self.center_origin[1][1])))
+        rect_max = mathutils.Vector((max(self.center_origin[0][0], self.center_origin[1][0]),
+                                     max(self.center_origin[0][1], self.center_origin[1][1])))
+
+    # ARRAY
+    if self.rows > 1:
+        rect_max.x = rect_min.x + (rect_max.x - rect_min.x) * self.rows + (self.gap_rows * (self.rows - 1))
+    if self.columns > 1:
+        rect_min.y = rect_max.y - (rect_max.y - rect_min.y) * self.columns - (self.gap_columns * (self.columns - 1))
 
     intersecting_objects = []
     for obj in objects:

--- a/tools/carver.py
+++ b/tools/carver.py
@@ -80,11 +80,13 @@ class TOPBAR_PT_carver_array(bpy.types.Panel):
         op = tool.operator_properties("object.carve")
 
         layout.prop(op, "rows")
-        layout.prop(op, "gap_rows", text="Gap")
+        layout.prop(op, "rows_direction", text="Direction", expand=True)
+        layout.prop(op, "rows_gap", text="Gap")
 
         layout.separator()
         layout.prop(op, "columns")
-        layout.prop(op, "gap_columns", text="Gap")
+        layout.prop(op, "columns_direction", text="Direction", expand=True)
+        layout.prop(op, "columns_gap", text="Gap")
 
 
 
@@ -227,20 +229,33 @@ class OBJECT_OT_carve(bpy.types.Operator):
         min = 1, soft_max = 16,
         default = 1,
     )
-    gap_rows: bpy.props.FloatProperty(
+    rows_gap: bpy.props.FloatProperty(
         name = "Gap between Rows",
-        soft_min = 1, soft_max = 250,
+        min = 0, soft_max = 250,
         default = 50,
     )
+    rows_direction: bpy.props.EnumProperty(
+        name = "Direction of Rows",
+        items = (('RIGHT', "Right", ""),
+                 ('LEFT', "Left", "")),
+        default = 'RIGHT',
+    )
+
     columns: bpy.props.IntProperty(
         name = "Columns",
         description = "Number of times shape is duplicated on Y axis",
         min = 1, soft_max = 16,
         default = 1,
     )
-    gap_columns: bpy.props.FloatProperty(
+    columns_direction: bpy.props.EnumProperty(
+        name = "Direction of Rows",
+        items = (('UP', "Up", ""),
+                 ('DOWN', "Down", "")),
+        default = 'DOWN',
+    )
+    columns_gap: bpy.props.FloatProperty(
         name = "Gap between Columns",
-        soft_min = 1, soft_max = 250,
+        min = 0, soft_max = 250,
         default = 50,
     )
 

--- a/tools/carver.py
+++ b/tools/carver.py
@@ -265,6 +265,7 @@ class OBJECT_OT_carve(bpy.types.Operator):
         self.view_vector = mathutils.Vector()
         self.verts = []
         self.cutter = None
+        self.duplicates = []
 
         args = (self, context)
         self._handle = bpy.types.SpaceView3D.draw_handler_add(carver_overlay, args, 'WINDOW', 'POST_PIXEL')

--- a/tools/carver.py
+++ b/tools/carver.py
@@ -488,7 +488,6 @@ class OBJECT_OT_carve(bpy.types.Operator):
             if self.shape == 'POLYLINE':
                 if not (event.type == 'RET' and event.value == 'PRESS') and (self.distance_from_first < 15):
                     self.mouse_path.append((event.mouse_region_x, event.mouse_region_y))
-                    self.mouse_path.append((event.mouse_region_x, event.mouse_region_y))
                 else:
                     # Confirm Cut (Polyline)
                     if self.closed == False:

--- a/tools/carver.py
+++ b/tools/carver.py
@@ -229,8 +229,8 @@ class OBJECT_OT_carve(bpy.types.Operator):
     )
     gap_rows: bpy.props.FloatProperty(
         name = "Gap between Rows",
-        soft_min = 1, soft_max = 10,
-        default = 2,
+        soft_min = 1, soft_max = 250,
+        default = 50,
     )
     columns: bpy.props.IntProperty(
         name = "Columns",
@@ -240,8 +240,8 @@ class OBJECT_OT_carve(bpy.types.Operator):
     )
     gap_columns: bpy.props.FloatProperty(
         name = "Gap between Columns",
-        soft_min = 1, soft_max = 10,
-        default = 2,
+        soft_min = 1, soft_max = 250,
+        default = 50,
     )
 
     # ADVANCED-properties


### PR DESCRIPTION
This PR implements array system for Carver tool. It is inspired by the system in "Carver" add-on (where it only works for object cutters) but implementation is different and written from scratch to be more general and work with any cutter.

---

UI/UX:
- Up, down, left, and right arrows add/subtract number of rows & columns during modal.
- Rows and columns (as well as gaps between them) can be set before operator too - in tool settings new "Array" dropdown.
- Columns are populated downwards by default, gaps to the left of the shape, but both can be changed in tool properties.
- 'A' modifier key to adjust gaps by mouse movement during modal.
- Array in screen-space, in general, seems particularly unusable in perspective view, but works great in orthographic.

Other changes:
- Renamed "..." dropdown to "Shape" and moved 'Rotation' and 'Vertices' inside it.

---

Implementation details:
- Refactored polyline code to match primitive shapes as much as possible and fit into general design, which is becoming clearer with each PR: list that is fed into `create_cutter_shape` is now created directly into `carver_overlay` by assigning to `self.verts`. That way order of creation is same for all shapes. Also turned its `coords` into 3d `mathutils.Vector` to feed into new `array` function easily (I thought about turning every other Vector into 2D, but I'll keep them 3D in order they're needed for surface alignment in future).
- Refactored polyline face creation in `create_cutter_shape` to handle creating multiple faces. Code is now cleaner and also doesn't create extra faces with 0 areas, which turns out it was.
- Deduplicated line intersect code in `create_cutter_shape` (which was getting too much now with duplicates) by extracting it as function.
- Simplified face creation for both primitives and polyline, so it could be extracted into separate function.