### PR TITLE
Fix #43: Cutter isn't generated around the median point of the canvas object

### DIFF
--- a/source/functions/mesh.py
+++ b/source/functions/mesh.py
@@ -19,7 +19,7 @@ def create_cutter_shape(self, context):
     if self.depth == 'CURSOR':
         plane_point = context.scene.cursor.location
     elif self.depth == 'VIEW':
-        plane_point = mathutils.Vector((0.0, 0.0, 0.0))
+        plane_point = mathutils.Vector(combined_bounding_box(self.selected_objects)[1])
 
 
     # Create Mesh & Object
@@ -61,7 +61,7 @@ def extrude(self, mesh):
     faces = [f for f in bm.faces]
 
     # move_the_mesh_towards_view
-    box_bounding = combined_bounding_box(self.selected_objects)
+    box_bounding = combined_bounding_box(self.selected_objects)[0]
     for face in faces:
         for vert in face.verts:
             vert.co += -self.view_depth * box_bounding
@@ -103,7 +103,9 @@ def combined_bounding_box(objects):
 
     # Calculate the diagonal of the combined bounding box
     bounding_box_diag = (max_corner - min_corner).length
-    return bounding_box_diag
+    # Calculate the center of bounding box
+    bounding_box_center = (max_corner + min_corner) * 0.5
+    return bounding_box_diag, bounding_box_center
 
 
 def create_face(context, direction, depth, bm, name, faces, verts, polyline=False):


### PR DESCRIPTION
Take the mesh median point into account