### PR TITLE
Fix (unreported): Incorrect operator assignment in Carve menu

### DIFF
--- a/source/ui.py
+++ b/source/ui.py
@@ -7,8 +7,8 @@ from .functions.list import list_canvas_cutters
 
 def carve_menu(self, context):
     layout = self.layout
-    layout.operator("object.carve_box", text="Box Carve").shape='BOX'
-    layout.operator("object.carve_box", text="Circle Carve").shape='CIRCLE'
+    layout.operator("object.carve_box", text="Box Carve")
+    layout.operator("object.carve_circle", text="Circle Carve")
     layout.operator("object.carve_polyline", text="Polyline Carve")
 
 


### PR DESCRIPTION
Exception has occurred: AttributeError       (note: full exception trace is shown but execution is paused at: draw)
'OBJECT_OT_carve_box' object has no attribute 'shape'
  File "C:\Users\xxx\AppData\Roaming\Blender Foundation\Blender\5.1\extensions\blender_org\bool_tool\ui.py", line 10, in carve_menu
    layout.operator("object.carve_box", text="Box Carve").shape='BOX'
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\xxx\AppData\Roaming\Blender Foundation\Blender\5.1\extensions\blender_org\bool_tool\ui.py", line 174, in draw (Current frame)
    carve_menu(self, context)
    ~~~~~~~~~~^^^^^^^^^^^^^^^
AttributeError: 'OBJECT_OT_carve_box' object has no attribute 'shape'